### PR TITLE
fix: file corruption by copy the array bytes

### DIFF
--- a/internal/usenet/corrupted-nzbs-manager/queue.go
+++ b/internal/usenet/corrupted-nzbs-manager/queue.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/javi11/usenet-drive/internal/usenet"
 	"github.com/javi11/usenet-drive/internal/utils"
 )
 
@@ -207,7 +208,7 @@ func (q *corruptedNzbsManager) List(ctx context.Context, limit, offset int, filt
 
 		jobs = append(jobs, cNzb{
 			ID:        int64(id),
-			Path:      path,
+			Path:      usenet.ReplaceFileExtension(path, ".nzb"),
 			CreatedAt: createdAt,
 			Error:     error,
 		})

--- a/internal/usenet/file-writer/file.go
+++ b/internal/usenet/file-writer/file.go
@@ -57,7 +57,6 @@ func openFile(
 	dryRun bool,
 	onClose func() error,
 ) (*file, error) {
-
 	if dryRun {
 		log.InfoContext(ctx, "Dry run. Skipping upload", "filename", filePath)
 	}
@@ -281,7 +280,6 @@ func (f *file) addSegment(b []byte, segmentIndex int64, retries int) error {
 
 	f.merr.Go(func() error {
 		defer f.cp.Free(conn)
-
 		a := f.buildArticleData(segmentIndex)
 		na := NewNttpArticle(b, a)
 		f.segments[segmentIndex] = nzb.NzbSegment{

--- a/internal/usenet/file-writer/segment.go
+++ b/internal/usenet/file-writer/segment.go
@@ -38,5 +38,8 @@ func (v *segmentBuffer) Clear() {
 }
 
 func (v *segmentBuffer) Bytes() []byte {
-	return v.buffer[:v.ptr]
+	tmp := make([]byte, v.ptr)
+	copy(tmp, v.buffer[:v.ptr])
+
+	return tmp
 }


### PR DESCRIPTION
fix: data corruption on upload
fix: return correct path on nzb corrupted files