### PR TITLE
feat: split upload and download providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The `Download` struct defines the Usenet provider for downloading.
 - `max_ahead_download_segments` (string): The maximum number of segments to download ahead. Default value is `1`. Be aware that increasing this value will increase the memory usage and connections usage.
 - `max_retries` (int): The maximum number of retries to download a segment. Default value is `8`.
 - `max_cache_size_in_mb` (int): The maximum size of the cache in MB. Default value is `1024`. WARN the tool will fill all this cache as soon as download start.
+- `providers` (UsenetProvider): Usenet providers to download files. (It is recommended an unlimited provider for this)
 
 ## Upload Struct
 
@@ -193,6 +194,7 @@ The `Upload` struct defines the Usenet provider for uploading.
 
 - `file_allow_list` ([]string): The list of allowed file extensions. For example, `[".mkv", ".mp4"]`, in this case only files with the extensions `.mkv` and `.mp4` will be uploaded to usenet. Take care not upload files that change frequently, like subtitules or text files, since they will be uploaded every time they change. In usenet you can not edit files. **_If using rclone crypt all file extensions will ends with .bin so in order to specify the real extension, you must add .bin at the end. Ex: .mkv.bin ._**
 - `max_retries` (int): The maximum number of retries to upload a segment. Default value is `8`.
+- `providers` (UsenetProvider): Usenet providers to upload files. (It is recommended a block account for this)
 
 ## UsenetProvider Struct
 

--- a/cmd/usenetdrive/main.go
+++ b/cmd/usenetdrive/main.go
@@ -73,7 +73,8 @@ var rootCmd = &cobra.Command{
 		// download and upload connection pool
 		connPool, err := connectionpool.NewConnectionPool(
 			connectionpool.WithFakeConnections(config.Usenet.FakeConnections),
-			connectionpool.WithProviders(config.Usenet.Providers),
+			connectionpool.WithDownloadProviders(config.Usenet.Download.Providers),
+			connectionpool.WithUploadProviders(config.Usenet.Upload.Providers),
 			connectionpool.WithClient(nntpCli),
 			connectionpool.WithLogger(log),
 		)

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -5,6 +5,13 @@ db_path: /config/usenet-drive.db
 usenet:
   download:
     max_ahead_download_segments: 1
+    providers:
+      - host: post.otherusenet.server
+        port: 119
+        username: pepe
+        password: 1234
+        ssl: false
+        max_connections: 25
   upload:
     groups:
       - alt.binaries.test
@@ -13,16 +20,10 @@ usenet:
       - .mp4
       - .avi
       - .ts
-  providers:
-    - host: post.otherusenet.server
-      port: 119
-      username: pepe
-      password: 1234
-      ssl: false
-      max_connections: 25
-    - host: my.usenet.server
-      port: 80
-      username: pepe
-      password: 1234
-      ssl: true
-      max_connections: 49
+    providers:
+      - host: my.usenet.server
+        port: 80
+        username: pepe
+        password: 1234
+        ssl: true
+        max_connections: 49

--- a/internal/adminpanel/handlers/getserverinfo.go
+++ b/internal/adminpanel/handlers/getserverinfo.go
@@ -8,19 +8,19 @@ import (
 )
 
 type serverInfoResponse struct {
-	RootFolderDiskUsage           serverinfo.DiskUsage         `json:"root_folder_disk_usage"`
-	UsenetDownloadOnlyConnections serverinfo.UsenetConnections `json:"download_only_usenet_connections"`
-	UsenetConnections             serverinfo.UsenetConnections `json:"usenet_connections"`
-	GlobalActivity                serverinfo.GlobalActivity    `json:"global_activity"`
+	RootFolderDiskUsage       serverinfo.DiskUsage         `json:"root_folder_disk_usage"`
+	UsenetDownloadConnections serverinfo.UsenetConnections `json:"download_usenet_connections"`
+	UsenetUploadConnections   serverinfo.UsenetConnections `json:"upload_usenet_connections"`
+	GlobalActivity            serverinfo.GlobalActivity    `json:"global_activity"`
 }
 
 func GetServerInfoHandler(si serverinfo.ServerInfo) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		result := serverInfoResponse{
-			RootFolderDiskUsage:           si.GetRootFolderDiskUsage(),
-			UsenetDownloadOnlyConnections: si.GetDownloadOnlyConnections(),
-			UsenetConnections:             si.GetConnections(),
-			GlobalActivity:                si.GetGlobalActivity(),
+			RootFolderDiskUsage:       si.GetRootFolderDiskUsage(),
+			UsenetDownloadConnections: si.GetDownloadConnections(),
+			UsenetUploadConnections:   si.GetUploadConnections(),
+			GlobalActivity:            si.GetGlobalActivity(),
 		}
 
 		return c.JSON(http.StatusOK, result)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,24 +23,25 @@ type Rclone struct {
 }
 
 type Usenet struct {
-	Download           Download         `yaml:"download"`
-	Upload             Upload           `yaml:"upload"`
-	Providers          []UsenetProvider `yaml:"providers"`
-	FakeConnections    bool             `yaml:"fake_connections" default:"false"`
-	ArticleSizeInBytes int64            `yaml:"article_size_in_bytes" default:"750000"`
+	Download           Download `yaml:"download"`
+	Upload             Upload   `yaml:"upload"`
+	FakeConnections    bool     `yaml:"fake_connections" default:"false"`
+	ArticleSizeInBytes int64    `yaml:"article_size_in_bytes" default:"750000"`
 }
 
 type Download struct {
-	MaxAheadDownloadSegments int `yaml:"max_ahead_download_segments"`
-	MaxRetries               int `yaml:"max_retries" default:"8"`
-	MaxCacheSizeInMB         int `yaml:"max_cache_size_in_mb" default:"512"`
+	MaxAheadDownloadSegments int              `yaml:"max_ahead_download_segments"`
+	MaxRetries               int              `yaml:"max_retries" default:"8"`
+	MaxCacheSizeInMB         int              `yaml:"max_cache_size_in_mb" default:"512"`
+	Providers                []UsenetProvider `yaml:"providers"`
 }
 
 type Upload struct {
-	DryRun        bool     `yaml:"dry_run" default:"false"`
-	FileAllowlist []string `yaml:"file_allow_list"`
-	MaxRetries    int      `yaml:"max_retries" default:"8"`
-	Groups        []string `yaml:"groups"`
+	DryRun        bool             `yaml:"dry_run" default:"false"`
+	FileAllowlist []string         `yaml:"file_allow_list"`
+	MaxRetries    int              `yaml:"max_retries" default:"8"`
+	Groups        []string         `yaml:"groups"`
+	Providers     []UsenetProvider `yaml:"providers"`
 }
 
 type UsenetProvider struct {
@@ -50,7 +51,6 @@ type UsenetProvider struct {
 	Password       string `yaml:"password" json:"-"`
 	TLS            bool   `yaml:"tls"`
 	MaxConnections int    `yaml:"max_connections"`
-	DownloadOnly   bool   `yaml:"download_only"`
 	InsecureSSL    bool   `yaml:"insecure_ssl" default:"false"`
 }
 

--- a/internal/serverinfo/serverinfo.go
+++ b/internal/serverinfo/serverinfo.go
@@ -8,8 +8,8 @@ import (
 
 type ServerInfo interface {
 	GetRootFolderDiskUsage() DiskUsage
-	GetConnections() UsenetConnections
-	GetDownloadOnlyConnections() UsenetConnections
+	GetUploadConnections() UsenetConnections
+	GetDownloadConnections() UsenetConnections
 	GetActivity() []Activity
 	GetGlobalActivity() GlobalActivity
 }
@@ -61,19 +61,19 @@ func (s *serverInfo) GetRootFolderDiskUsage() DiskUsage {
 	}
 }
 
-func (s *serverInfo) GetConnections() UsenetConnections {
+func (s *serverInfo) GetUploadConnections() UsenetConnections {
 	return UsenetConnections{
-		Total:  s.conPool.GetMaxConnections(),
-		Free:   s.conPool.GetFreeConnections(),
-		Active: s.conPool.GetMaxConnections() - s.conPool.GetFreeConnections(),
+		Total:  s.conPool.GetMaxUploadConnections(),
+		Free:   s.conPool.GetUploadFreeConnections(),
+		Active: s.conPool.GetMaxUploadConnections() - s.conPool.GetUploadFreeConnections(),
 	}
 }
 
-func (s *serverInfo) GetDownloadOnlyConnections() UsenetConnections {
+func (s *serverInfo) GetDownloadConnections() UsenetConnections {
 	return UsenetConnections{
-		Total:  s.conPool.GetMaxDownloadOnlyConnections(),
-		Free:   s.conPool.GetDownloadOnlyFreeConnections(),
-		Active: s.conPool.GetMaxDownloadOnlyConnections() - s.conPool.GetDownloadOnlyFreeConnections(),
+		Total:  s.conPool.GetMaxDownloadConnections(),
+		Free:   s.conPool.GetDownloadFreeConnections(),
+		Active: s.conPool.GetMaxDownloadConnections() - s.conPool.GetDownloadFreeConnections(),
 	}
 }
 

--- a/internal/usenet/connectionpool/config.go
+++ b/internal/usenet/connectionpool/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Config struct {
-	providers       []config.UsenetProvider
-	log             *slog.Logger
-	fakeConnections bool
-	cli             nntpcli.Client
+	downloadProviders []config.UsenetProvider
+	uploadProviders   []config.UsenetProvider
+	log               *slog.Logger
+	fakeConnections   bool
+	cli               nntpcli.Client
 }
 
 type Option func(*Config)
@@ -28,9 +29,15 @@ func WithClient(cli nntpcli.Client) Option {
 	}
 }
 
-func WithProviders(providers []config.UsenetProvider) Option {
+func WithDownloadProviders(providers []config.UsenetProvider) Option {
 	return func(c *Config) {
-		c.providers = providers
+		c.downloadProviders = providers
+	}
+}
+
+func WithUploadProviders(providers []config.UsenetProvider) Option {
+	return func(c *Config) {
+		c.uploadProviders = providers
 	}
 }
 

--- a/internal/usenet/connectionpool/connectionpool_mock.go
+++ b/internal/usenet/connectionpool/connectionpool_mock.go
@@ -77,60 +77,46 @@ func (mr *MockUsenetConnectionPoolMockRecorder) GetDownloadConnection() *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadConnection", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetDownloadConnection))
 }
 
-// GetDownloadOnlyFreeConnections mocks base method.
-func (m *MockUsenetConnectionPool) GetDownloadOnlyFreeConnections() int {
+// GetDownloadFreeConnections mocks base method.
+func (m *MockUsenetConnectionPool) GetDownloadFreeConnections() int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDownloadOnlyFreeConnections")
+	ret := m.ctrl.Call(m, "GetDownloadFreeConnections")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-// GetDownloadOnlyFreeConnections indicates an expected call of GetDownloadOnlyFreeConnections.
-func (mr *MockUsenetConnectionPoolMockRecorder) GetDownloadOnlyFreeConnections() *gomock.Call {
+// GetDownloadFreeConnections indicates an expected call of GetDownloadFreeConnections.
+func (mr *MockUsenetConnectionPoolMockRecorder) GetDownloadFreeConnections() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadOnlyFreeConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetDownloadOnlyFreeConnections))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadFreeConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetDownloadFreeConnections))
 }
 
-// GetFreeConnections mocks base method.
-func (m *MockUsenetConnectionPool) GetFreeConnections() int {
+// GetMaxDownloadConnections mocks base method.
+func (m *MockUsenetConnectionPool) GetMaxDownloadConnections() int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFreeConnections")
+	ret := m.ctrl.Call(m, "GetMaxDownloadConnections")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-// GetFreeConnections indicates an expected call of GetFreeConnections.
-func (mr *MockUsenetConnectionPoolMockRecorder) GetFreeConnections() *gomock.Call {
+// GetMaxDownloadConnections indicates an expected call of GetMaxDownloadConnections.
+func (mr *MockUsenetConnectionPoolMockRecorder) GetMaxDownloadConnections() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFreeConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetFreeConnections))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxDownloadConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetMaxDownloadConnections))
 }
 
-// GetMaxConnections mocks base method.
-func (m *MockUsenetConnectionPool) GetMaxConnections() int {
+// GetMaxUploadConnections mocks base method.
+func (m *MockUsenetConnectionPool) GetMaxUploadConnections() int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxConnections")
+	ret := m.ctrl.Call(m, "GetMaxUploadConnections")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-// GetMaxConnections indicates an expected call of GetMaxConnections.
-func (mr *MockUsenetConnectionPoolMockRecorder) GetMaxConnections() *gomock.Call {
+// GetMaxUploadConnections indicates an expected call of GetMaxUploadConnections.
+func (mr *MockUsenetConnectionPoolMockRecorder) GetMaxUploadConnections() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetMaxConnections))
-}
-
-// GetMaxDownloadOnlyConnections mocks base method.
-func (m *MockUsenetConnectionPool) GetMaxDownloadOnlyConnections() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxDownloadOnlyConnections")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// GetMaxDownloadOnlyConnections indicates an expected call of GetMaxDownloadOnlyConnections.
-func (mr *MockUsenetConnectionPoolMockRecorder) GetMaxDownloadOnlyConnections() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxDownloadOnlyConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetMaxDownloadOnlyConnections))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxUploadConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetMaxUploadConnections))
 }
 
 // GetUploadConnection mocks base method.
@@ -146,4 +132,18 @@ func (m *MockUsenetConnectionPool) GetUploadConnection() (nntpcli.Connection, er
 func (mr *MockUsenetConnectionPoolMockRecorder) GetUploadConnection() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploadConnection", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetUploadConnection))
+}
+
+// GetUploadFreeConnections mocks base method.
+func (m *MockUsenetConnectionPool) GetUploadFreeConnections() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUploadFreeConnections")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetUploadFreeConnections indicates an expected call of GetUploadFreeConnections.
+func (mr *MockUsenetConnectionPoolMockRecorder) GetUploadFreeConnections() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploadFreeConnections", reflect.TypeOf((*MockUsenetConnectionPool)(nil).GetUploadFreeConnections))
 }

--- a/internal/usenet/filewriter/file.go
+++ b/internal/usenet/filewriter/file.go
@@ -114,6 +114,7 @@ func openFile(
 			ChunkSize:     segmentSize,
 		},
 		sessionId: sessionId,
+		sr:        sr,
 	}, nil
 }
 

--- a/internal/usenet/filewriter/utils.go
+++ b/internal/usenet/filewriter/utils.go
@@ -1,8 +1,6 @@
 package filewriter
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -10,10 +8,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func generateHashFromString(s string) (string, error) {
-	hash := md5.Sum([]byte(s))
-	return hex.EncodeToString(hash[:]), nil
-}
+const toolName = "UsenetDrive"
 
 func generateRandomPoster() string {
 	email := faker.Email()
@@ -28,7 +23,7 @@ func generateMessageId() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s@usenetdrive", id.String()), nil
+	return fmt.Sprintf("%s@%s", id.String(), toolName), nil
 }
 
 func isNzbFile(name string) bool {

--- a/pkg/nntpcli/connection_mock.go
+++ b/pkg/nntpcli/connection_mock.go
@@ -63,18 +63,18 @@ func (mr *MockConnectionMockRecorder) Body(id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Body", reflect.TypeOf((*MockConnection)(nil).Body), id)
 }
 
-// IsDownloadOnly mocks base method.
-func (m *MockConnection) IsDownloadOnly() bool {
+// GetConnectionType mocks base method.
+func (m *MockConnection) GetConnectionType() ConnectionType {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDownloadOnly")
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "GetConnectionType")
+	ret0, _ := ret[0].(ConnectionType)
 	return ret0
 }
 
-// IsDownloadOnly indicates an expected call of IsDownloadOnly.
-func (mr *MockConnectionMockRecorder) IsDownloadOnly() *gomock.Call {
+// GetConnectionType indicates an expected call of GetConnectionType.
+func (mr *MockConnectionMockRecorder) GetConnectionType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDownloadOnly", reflect.TypeOf((*MockConnection)(nil).IsDownloadOnly))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionType", reflect.TypeOf((*MockConnection)(nil).GetConnectionType))
 }
 
 // Post mocks base method.
@@ -91,18 +91,18 @@ func (mr *MockConnectionMockRecorder) Post(p, chunkSize interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockConnection)(nil).Post), p, chunkSize)
 }
 
-// Provider mocks base method.
-func (m *MockConnection) Provider() string {
+// ProviderID mocks base method.
+func (m *MockConnection) ProviderID() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Provider")
+	ret := m.ctrl.Call(m, "ProviderID")
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// Provider indicates an expected call of Provider.
-func (mr *MockConnectionMockRecorder) Provider() *gomock.Call {
+// ProviderID indicates an expected call of ProviderID.
+func (mr *MockConnectionMockRecorder) ProviderID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockConnection)(nil).Provider))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderID", reflect.TypeOf((*MockConnection)(nil).ProviderID))
 }
 
 // Quit mocks base method.

--- a/pkg/nntpcli/fake_connection.go
+++ b/pkg/nntpcli/fake_connection.go
@@ -6,26 +6,22 @@ import (
 )
 
 type fakeConnection struct {
-	host         string
-	username     string
-	downloadOnly bool
+	connectionType ConnectionType
+	providerId     string
 }
 
-func NewFakeConnection(host string, downloadOnly bool) Connection {
+func NewFakeConnection(host string, providerId string, connectionType ConnectionType) Connection {
 	return &fakeConnection{}
 }
 
-func (c *fakeConnection) Provider() string {
-	return ProviderName(c.host, c.username)
+func (c *fakeConnection) ProviderID() string {
+	return c.providerId
 }
-
-func (c *fakeConnection) IsDownloadOnly() bool {
-	return c.downloadOnly
+func (c *fakeConnection) GetConnectionType() ConnectionType {
+	return c.connectionType
 }
 
 func (c *fakeConnection) Authenticate(username, password string) error {
-	c.username = username
-
 	return nil
 }
 

--- a/pkg/nntpcli/nntp.go
+++ b/pkg/nntpcli/nntp.go
@@ -15,7 +15,7 @@ type TimeData struct {
 }
 
 type Client interface {
-	Dial(address string, port int, useTLS bool, insecureSSL bool, downloadOnly bool) (Connection, error)
+	Dial(address string, port int, useTLS bool, insecureSSL bool, providerId string, connectionType ConnectionType) (Connection, error)
 }
 
 type client struct {
@@ -36,7 +36,7 @@ func New(options ...Option) Client {
 }
 
 // Dial connects to an NNTP server
-func (c *client) Dial(host string, port int, useTLS bool, insecureSSL bool, downloadOnly bool) (Connection, error) {
+func (c *client) Dial(host string, port int, useTLS bool, insecureSSL bool, providerId string, connectionType ConnectionType) (Connection, error) {
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", host, port), c.timeout)
 	if err != nil {
 		return nil, err
@@ -50,8 +50,8 @@ func (c *client) Dial(host string, port int, useTLS bool, insecureSSL bool, down
 			return nil, err
 		}
 
-		return newConn(tlsConn, host, downloadOnly)
+		return newConn(tlsConn, host, providerId, connectionType)
 	} else {
-		return newConn(conn, host, downloadOnly)
+		return newConn(conn, host, providerId, connectionType)
 	}
 }

--- a/pkg/nntpcli/nntp_mock.go
+++ b/pkg/nntpcli/nntp_mock.go
@@ -34,16 +34,16 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Dial mocks base method.
-func (m *MockClient) Dial(address string, port int, useTLS, insecureSSL, downloadOnly bool) (Connection, error) {
+func (m *MockClient) Dial(address string, port int, useTLS, insecureSSL bool, providerId string, connectionType ConnectionType) (Connection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dial", address, port, useTLS, insecureSSL, downloadOnly)
+	ret := m.ctrl.Call(m, "Dial", address, port, useTLS, insecureSSL, providerId, connectionType)
 	ret0, _ := ret[0].(Connection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dial indicates an expected call of Dial.
-func (mr *MockClientMockRecorder) Dial(address, port, useTLS, insecureSSL, downloadOnly interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Dial(address, port, useTLS, insecureSSL, providerId, connectionType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), address, port, useTLS, insecureSSL, downloadOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dial", reflect.TypeOf((*MockClient)(nil).Dial), address, port, useTLS, insecureSSL, providerId, connectionType)
 }

--- a/pkg/nntpcli/nntp_test.go
+++ b/pkg/nntpcli/nntp_test.go
@@ -58,7 +58,7 @@ func TestDial(t *testing.T) {
 	// create a client and dial the mock server
 	t.Run("Dial", func(t *testing.T) {
 		c := &client{timeout: 5 * time.Second}
-		conn, err := c.Dial(host, port, false, false, false)
+		conn, err := c.Dial(host, port, false, false, "id1", DownloadConnection)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	})
@@ -66,7 +66,7 @@ func TestDial(t *testing.T) {
 	// create a client and dial a non-existent server
 	t.Run("DialFail", func(t *testing.T) {
 		c := &client{timeout: 5 * time.Second}
-		_, err = c.Dial("127.0.0.1", 12345, false, false, false)
+		_, err = c.Dial("127.0.0.1", 12345, false, false, "id1", DownloadConnection)
 		assert.Error(t, err)
 	})
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -43,8 +43,8 @@ const useStyles = createStyles((theme) => ({
 
 interface ServerInfo {
     root_folder_disk_usage: DiskUsage;
-    usenet_connections: UsenetConnections;
-    download_only_usenet_connections: UsenetConnections;
+    upload_usenet_connections: UsenetConnections;
+    download_usenet_connections: UsenetConnections;
     global_activity: {
         download_speed: number;
         upload_speed: number;
@@ -61,12 +61,12 @@ export default function Home() {
             free: 0,
             folder: '',
         },
-        download_only_usenet_connections: {
+        download_usenet_connections: {
             total: 0,
             active: 0,
             free: 0,
         },
-        usenet_connections: {
+        upload_usenet_connections: {
             total: 0,
             active: 0,
             free: 0,
@@ -128,8 +128,8 @@ export default function Home() {
             <SimpleGrid cols={2} spacing="xl" mt={50} breakpoints={[{ maxWidth: 'md', cols: 1 }]}>
                 <NetworkUsageCard data={serverInfo.global_activity} />
                 <DiskUsageCard data={serverInfo.root_folder_disk_usage} />
-                <UsenetConnectionsCard data={serverInfo.download_only_usenet_connections} title="Download only" />
-                <UsenetConnectionsCard data={serverInfo.usenet_connections} title="Available" />
+                <UsenetConnectionsCard data={serverInfo.download_usenet_connections} title="Download" />
+                <UsenetConnectionsCard data={serverInfo.upload_usenet_connections} title="Upload" />
             </SimpleGrid>
         </Container>
     );


### PR DESCRIPTION
- Since you can have block accounts for upload, there is no point on having a single provider for upload/download

perf: improve how connections are used
fix: connection information on frontend