### PR TITLE
fix: do not mark file as corrupted for a connection issue

### DIFF
--- a/internal/usenet/connectionpool/connectionpool.go
+++ b/internal/usenet/connectionpool/connectionpool.go
@@ -48,7 +48,7 @@ func NewConnectionPool(options ...Option) (UsenetConnectionPool, error) {
 	close := func(value nntpcli.Connection) {
 		err := value.Quit()
 		if err != nil {
-			config.log.Error(fmt.Sprintf("error closing connection: %v", err))
+			config.log.Debug(fmt.Sprintf("error closing connection: %v", err))
 		}
 	}
 

--- a/internal/usenet/connectionpool/connectionpool.go
+++ b/internal/usenet/connectionpool/connectionpool.go
@@ -41,8 +41,14 @@ func NewConnectionPool(options ...Option) (UsenetConnectionPool, error) {
 		option(config)
 	}
 
-	downloadPools := make([]*puddle.Pool[nntpcli.Connection], 0)
-	uploadPools := make([]*puddle.Pool[nntpcli.Connection], 0)
+	downloadPools := make(
+		[]*puddle.Pool[nntpcli.Connection],
+		len(config.downloadProviders),
+	)
+	uploadPools := make(
+		[]*puddle.Pool[nntpcli.Connection],
+		len(config.uploadProviders),
+	)
 
 	// close Specify the method to close the connection
 	close := func(value nntpcli.Connection) {
@@ -52,10 +58,10 @@ func NewConnectionPool(options ...Option) (UsenetConnectionPool, error) {
 		}
 	}
 
-	for _, provider := range config.downloadProviders {
+	for i, provider := range config.downloadProviders {
 		p := provider
 		providerOptions := &nntpcli.ProviderOptions{
-			JoinGroup: true,
+			JoinGroup: p.JoinGroup,
 		}
 
 		factory := func(ctx context.Context) (nntpcli.Connection, error) {
@@ -73,13 +79,13 @@ func NewConnectionPool(options ...Option) (UsenetConnectionPool, error) {
 			return nil, err
 		}
 
-		downloadPools = append(downloadPools, dp)
+		downloadPools[i] = dp
 	}
 
-	for _, provider := range config.uploadProviders {
+	for i, provider := range config.uploadProviders {
 		p := provider
 		providerOptions := &nntpcli.ProviderOptions{
-			JoinGroup: true,
+			JoinGroup: p.JoinGroup,
 		}
 
 		factory := func(ctx context.Context) (nntpcli.Connection, error) {
@@ -97,7 +103,7 @@ func NewConnectionPool(options ...Option) (UsenetConnectionPool, error) {
 			return nil, err
 		}
 
-		uploadPools = append(uploadPools, up)
+		uploadPools[i] = up
 	}
 
 	return &connectionPool{

--- a/internal/usenet/filereader/buffer_test.go
+++ b/internal/usenet/filereader/buffer_test.go
@@ -853,7 +853,7 @@ func TestBuffer_downloadSegment(t *testing.T) {
 			log: slog.Default(),
 		}
 		cache.EXPECT().Get("1").Return(nil, errors.New("not found")).Times(1)
-		mockPool.EXPECT().GetDownloadConnection(gomock.Any()).Return(nil, errors.New("error")).Times(5)
+		mockPool.EXPECT().GetDownloadConnection(gomock.Any()).Return(nil, errors.New("error")).Times(1)
 
 		_, err := buf.downloadSegment(context.Background(), segment, groups)
 		assert.Error(t, err)

--- a/internal/usenet/filereader/buffer_test.go
+++ b/internal/usenet/filereader/buffer_test.go
@@ -684,7 +684,9 @@ func TestBuffer_Close(t *testing.T) {
 				maxDownloadRetries:       5,
 				maxAheadDownloadSegments: 0,
 			},
-			log: slog.Default(),
+			log:         slog.Default(),
+			closed:      make(chan bool),
+			nextSegment: make(chan *nzb.NzbSegment),
 		}
 
 		err := buf.Close()
@@ -715,9 +717,10 @@ func TestBuffer_Close(t *testing.T) {
 				maxDownloadRetries:       5,
 				maxAheadDownloadSegments: 1,
 			},
-			log:    slog.Default(),
-			closed: closed,
-			wg:     &sync.WaitGroup{},
+			log:         slog.Default(),
+			closed:      closed,
+			nextSegment: make(chan *nzb.NzbSegment),
+			wg:          &sync.WaitGroup{},
 		}
 
 		wg := &sync.WaitGroup{}

--- a/internal/usenet/filewriter/file_test.go
+++ b/internal/usenet/filewriter/file_test.go
@@ -632,6 +632,8 @@ func TestReadFrom(t *testing.T) {
 		// Second connection works as expected
 		cp.EXPECT().GetUploadConnection(gomock.Any()).Return(mockResource2, nil).Times(10)
 		cp.EXPECT().Free(mockResource2).Times(10)
+		cp.EXPECT().Close(mockResource).Times(1)
+
 		fs.EXPECT().WriteFile("test.nzb", gomock.Any(), os.FileMode(0644)).Return(nil)
 		mockSr.EXPECT().AddTimeData(gomock.Any(), gomock.Any()).Times(10)
 		mockSr.EXPECT().FinishUpload(gomock.Any()).Times(1)

--- a/pkg/nntpcli/errors.go
+++ b/pkg/nntpcli/errors.go
@@ -40,17 +40,20 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	if _, ok := err.(net.Error); ok {
+	var netErr net.Error
+	if ok := errors.As(err, &netErr); ok {
 		return true
 	}
 
-	if _, ok := err.(ProtocolError); ok {
+	var protocolErr ProtocolError
+	if ok := errors.As(err, &protocolErr); ok {
 		return true
 	}
 
-	if e, ok := err.(NntpError); ok {
+	var nntpErr NntpError
+	if ok := errors.As(err, &nntpErr); ok {
 		for _, r := range retirableErrors {
-			if e.Code == r {
+			if nntpErr.Code == r {
 				return true
 			}
 		}


### PR DESCRIPTION
fix: some concurrency errors
fix: do not log error when close connection fails

Closes #64 