### PR TITLE
perf: start go routines on open file instead that on demand

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${cwd}/cmd/usenetdrive",
+            "program": "${cwd}/cmd/usenetdrive/main.go",
             "args": ["-c", "${cwd}/example/config/config.yaml"]
         }
     ]

--- a/internal/usenet/filereader/file.go
+++ b/internal/usenet/filereader/file.go
@@ -123,6 +123,9 @@ func (f *file) Close() error {
 	err := f.innerFile.Close()
 	err2 := f.buffer.Close()
 
+	f.buffer = nil
+	f.innerFile = nil
+
 	err = errors.Join(err, err2)
 	if err != nil {
 		return err

--- a/internal/usenet/filereader/file_test.go
+++ b/internal/usenet/filereader/file_test.go
@@ -235,23 +235,22 @@ func TestCloseFile(t *testing.T) {
 	mockBuffer := NewMockBuffer(ctrl)
 	onClosedCalled := false
 	mockSr := status.NewMockStatusReporter(ctrl)
-
-	f := &file{
-		path:      "test.nzb",
-		buffer:    mockBuffer,
-		innerFile: mockFile,
-		fsMutex:   sync.RWMutex{},
-		log:       log,
-		metadata:  usenet.Metadata{},
-		onClose: func() error {
-			onClosedCalled = true
-			return nil
-		},
-		cNzb: mockCNzb,
-		fs:   fs,
-		sr:   mockSr,
-	}
 	t.Run("Error", func(t *testing.T) {
+		f := &file{
+			path:      "test.nzb",
+			buffer:    mockBuffer,
+			innerFile: mockFile,
+			fsMutex:   sync.RWMutex{},
+			log:       log,
+			metadata:  usenet.Metadata{},
+			onClose: func() error {
+				onClosedCalled = true
+				return nil
+			},
+			cNzb: mockCNzb,
+			fs:   fs,
+			sr:   mockSr,
+		}
 		mockFile.EXPECT().Close().Return(os.ErrPermission).Times(1)
 		mockBuffer.EXPECT().Close().Return(nil).Times(1)
 		mockSr.EXPECT().FinishDownload(gomock.Any()).Times(1)
@@ -263,6 +262,21 @@ func TestCloseFile(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
+		f := &file{
+			path:      "test.nzb",
+			buffer:    mockBuffer,
+			innerFile: mockFile,
+			fsMutex:   sync.RWMutex{},
+			log:       log,
+			metadata:  usenet.Metadata{},
+			onClose: func() error {
+				onClosedCalled = true
+				return nil
+			},
+			cNzb: mockCNzb,
+			fs:   fs,
+			sr:   mockSr,
+		}
 		mockFile.EXPECT().Close().Return(nil).Times(1)
 		mockBuffer.EXPECT().Close().Return(nil).Times(1)
 		mockSr.EXPECT().FinishDownload(gomock.Any()).Times(1)
@@ -274,6 +288,21 @@ func TestCloseFile(t *testing.T) {
 	})
 
 	t.Run("NoOnCloseFunction", func(t *testing.T) {
+		f := &file{
+			path:      "test.nzb",
+			buffer:    mockBuffer,
+			innerFile: mockFile,
+			fsMutex:   sync.RWMutex{},
+			log:       log,
+			metadata:  usenet.Metadata{},
+			onClose: func() error {
+				onClosedCalled = true
+				return nil
+			},
+			cNzb: mockCNzb,
+			fs:   fs,
+			sr:   mockSr,
+		}
 		f.onClose = nil
 		mockFile.EXPECT().Close().Return(nil).Times(1)
 		mockBuffer.EXPECT().Close().Return(nil).Times(1)

--- a/internal/usenet/filereader/fileinfo.go
+++ b/internal/usenet/filereader/fileinfo.go
@@ -51,6 +51,7 @@ func NewFileInfoWithStat(
 		log.Error(fmt.Sprintf("Error getting file %s, this file will be ignored", path), "error", err)
 		return nil, err
 	}
+	defer f.Close()
 
 	reader := nzbloader.NewNzbReader(f)
 	defer func() {
@@ -58,6 +59,7 @@ func NewFileInfoWithStat(
 		if err := f.Close(); err != nil {
 			log.Error(fmt.Sprintf("Error closing file %s", path), "error", err)
 		}
+		reader = nil
 	}()
 
 	metadata, err = reader.GetMetadata()

--- a/internal/usenet/filewriter/file.go
+++ b/internal/usenet/filewriter/file.go
@@ -38,7 +38,7 @@ type nzbMetadata struct {
 type file struct {
 	io.ReaderFrom
 	dryRun           bool
-	nzbMetadata      *nzbMetadata
+	nzbMetadata      nzbMetadata
 	metadata         *usenet.Metadata
 	cp               connectionpool.UsenetConnectionPool
 	maxUploadRetries int
@@ -98,7 +98,7 @@ func openFile(
 		onClose:          onClose,
 		flag:             flag,
 		perm:             perm,
-		nzbMetadata: &nzbMetadata{
+		nzbMetadata: nzbMetadata{
 			fileNameHash:     fileNameHash,
 			filePath:         filePath,
 			parts:            parts,
@@ -349,8 +349,8 @@ func (f *file) WriteString(s string) (int, error) {
 	return 0, os.ErrPermission
 }
 
-func (f *file) getMetadata() *usenet.Metadata {
-	return f.metadata
+func (f *file) getMetadata() usenet.Metadata {
+	return *f.metadata
 }
 
 func (f *file) addSegment(ctx context.Context, conn connectionpool.Resource, segments []*nzb.NzbSegment, b []byte, segmentIndex int) error {

--- a/internal/usenet/filewriter/file_test.go
+++ b/internal/usenet/filewriter/file_test.go
@@ -90,7 +90,7 @@ func TestCloseFile(t *testing.T) {
 		log:              log,
 		flag:             os.O_WRONLY,
 		perm:             os.FileMode(0644),
-		nzbMetadata: &nzbMetadata{
+		nzbMetadata: nzbMetadata{
 			fileNameHash:     fileNameHash,
 			filePath:         filePath,
 			parts:            parts,
@@ -152,7 +152,7 @@ func TestSystemFileMethods(t *testing.T) {
 		log:              log,
 		flag:             os.O_WRONLY,
 		perm:             os.FileMode(0644),
-		nzbMetadata: &nzbMetadata{
+		nzbMetadata: nzbMetadata{
 			fileNameHash:     fileNameHash,
 			filePath:         filePath,
 			parts:            parts,
@@ -302,7 +302,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -356,7 +356,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            1,
@@ -404,7 +404,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -452,7 +452,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -504,7 +504,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -550,7 +550,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -597,7 +597,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -657,7 +657,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -716,7 +716,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,
@@ -768,7 +768,7 @@ func TestReadFrom(t *testing.T) {
 			log:              log,
 			flag:             os.O_WRONLY,
 			perm:             os.FileMode(0644),
-			nzbMetadata: &nzbMetadata{
+			nzbMetadata: nzbMetadata{
 				fileNameHash:     fileNameHash,
 				filePath:         filePath,
 				parts:            parts,

--- a/internal/usenet/filewriter/fileinfo.go
+++ b/internal/usenet/filewriter/fileinfo.go
@@ -9,10 +9,10 @@ import (
 
 type fileInfo struct {
 	name     string
-	metadata *usenet.Metadata
+	metadata usenet.Metadata
 }
 
-func NewFileInfo(metadata *usenet.Metadata, name string) (fs.FileInfo, error) {
+func NewFileInfo(metadata usenet.Metadata, name string) (fs.FileInfo, error) {
 	return &fileInfo{
 		metadata: metadata,
 		name:     usenet.ReplaceFileExtension(name, metadata.FileExtension),

--- a/internal/usenet/filewriter/nttparticle.go
+++ b/internal/usenet/filewriter/nttparticle.go
@@ -24,7 +24,7 @@ type ArticleData struct {
 }
 
 func ArticleToBytes(p []byte, data *ArticleData) (*bytes.Buffer, error) {
-	buf := new(bytes.Buffer)
+	buf := &bytes.Buffer{}
 	buf.WriteString(fmt.Sprintf("From: %s\r\n", data.poster))
 	buf.WriteString(fmt.Sprintf("Newsgroups: %s\r\n", data.group))
 	buf.WriteString(fmt.Sprintf("Message-ID: <%s>\r\n", data.msgId))

--- a/internal/usenet/nzbloader/nzbreader_mock.go
+++ b/internal/usenet/nzbloader/nzbreader_mock.go
@@ -78,10 +78,10 @@ func (mr *MockNzbReaderMockRecorder) GetMetadata() *gomock.Call {
 }
 
 // GetSegment mocks base method.
-func (m *MockNzbReader) GetSegment(segmentIndex int) (*nzb.NzbSegment, bool) {
+func (m *MockNzbReader) GetSegment(segmentIndex int) (nzb.NzbSegment, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSegment", segmentIndex)
-	ret0, _ := ret[0].(*nzb.NzbSegment)
+	ret0, _ := ret[0].(nzb.NzbSegment)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/internal/webdav/file.go
+++ b/internal/webdav/file.go
@@ -53,6 +53,10 @@ func (f *file) Chown(uid, gid int) error {
 }
 
 func (f *file) Close() error {
+	defer func() {
+		f.innerFile = nil
+	}()
+
 	err := f.innerFile.Close()
 	if err != nil {
 		return err


### PR DESCRIPTION
Instead of start the download go routines on demand, start all of them on open the file and maintain them opened until file is closed

fix: clear all buffers on close file