### PR TITLE
perf: refactor buffer implementation and update nntpcli connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ The `Download` struct defines the Usenet provider for downloading.
 
 - `max_download_workers` (int): The maximum number of download workers. Default value is `3`. WARN the tool will use 1 connections per worker. Min value is 1.
 - `max_retries` (int): The maximum number of retries to download a segment. Default value is `8`.
-- `max_buffer_size_in_mb` (int): The maximum buffer size in MB peer download session. Default value is `30`.
 - `providers` (UsenetProvider): Usenet providers to download files. (It is recommended an unlimited provider for this)
 
 ## Upload Struct

--- a/cmd/usenetdrive/main.go
+++ b/cmd/usenetdrive/main.go
@@ -129,7 +129,6 @@ var rootCmd = &cobra.Command{
 			filereader.WithMaxDownloadRetries(config.Usenet.Download.MaxRetries),
 			filereader.WithMaxDownloadWorkers(config.Usenet.Download.MaxDownloadWorkers),
 			filereader.WithSegmentSize(config.Usenet.ArticleSizeInBytes),
-			filereader.WithMaxBufferSizeInMb(config.Usenet.Download.MaxBufferSizeInMb),
 			filereader.WithDebug(config.Debug),
 			filereader.WithStatusReporter(sr),
 		)

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -4,7 +4,6 @@ api_port: 8081
 db_path: /config/usenet-drive.db
 usenet:
   download:
-    max_buffer_size_in_mb: 30
     max_download_workers: 3
     providers:
       - host: post.otherusenet.server

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,7 +33,6 @@ type Usenet struct {
 type Download struct {
 	MaxDownloadWorkers int              `yaml:"max_download_workers" default:"3"`
 	MaxRetries         int              `yaml:"max_retries" default:"8"`
-	MaxBufferSizeInMb  int              `yaml:"max_buffer_size_in_mb" default:"30"`
 	Providers          []UsenetProvider `yaml:"providers"`
 }
 

--- a/internal/usenet/filereader/buffer.go
+++ b/internal/usenet/filereader/buffer.go
@@ -295,7 +295,7 @@ func (b *buffer) downloadSegment(ctx context.Context, segment nzb.NzbSegment, gr
 			}
 		}
 
-		err = nntpConn.Body(fmt.Sprintf("<%v>", segment.Id), chunk)
+		err = nntpConn.Body(segment.Id, chunk)
 		if err != nil {
 			// Final segments has less bytes than chunkSize. Do not error if it's the case
 			if err != io.ErrUnexpectedEOF {

--- a/internal/usenet/filereader/buffer.go
+++ b/internal/usenet/filereader/buffer.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
-	"github.com/bool64/cache"
 	"github.com/javi11/usenet-drive/internal/usenet"
 	"github.com/javi11/usenet-drive/internal/usenet/connectionpool"
 	"github.com/javi11/usenet-drive/internal/usenet/corruptednzbsmanager"
@@ -27,7 +26,7 @@ var (
 	ErrSeekTooFar    = errors.New("seek: too far")
 )
 
-const toMb = 1e+6
+const toMb = 1024 * 1024
 
 type Buffer interface {
 	io.ReaderAt
@@ -42,7 +41,7 @@ type buffer struct {
 	nzbReader              nzbloader.NzbReader
 	nzbGroups              []string
 	ptr                    int64
-	segmentsBuffer         *cache.ShardedMapOf[[]byte]
+	segmentsBuffer         *sync.Map
 	cp                     connectionpool.UsenetConnectionPool
 	chunkSize              int
 	dc                     downloadConfig
@@ -71,19 +70,7 @@ func NewBuffer(
 		return nil, err
 	}
 
-	bufferLimit := uint64(dc.maxBufferSizeInMb) * toMb
-
-	c := cache.NewShardedMapOf[[]byte](func(cfg *cache.Config) {
-		cfg.TimeToLive = 13 * time.Minute
-		cfg.Logger = cache.NewLogger(func(ctx context.Context, msg string, keysAndValues ...interface{}) {
-			log.DebugContext(ctx, "cache failed: %s %v", msg, keysAndValues)
-		}, nil, nil, nil)
-		cfg.DeleteExpiredAfter = 1 * time.Minute
-		cfg.DeleteExpiredJobInterval = 10 * time.Minute
-		cfg.HeapInUseSoftLimit = bufferLimit
-		cfg.EvictFraction = 0.1
-		cfg.SysMemSoftLimit = bufferLimit
-	})
+	c := &sync.Map{}
 
 	retyTimeout := time.Duration(dc.maxDownloadRetries) * time.Second
 	buffer := &buffer{
@@ -96,7 +83,7 @@ func NewBuffer(
 		cp:                     cp,
 		dc:                     dc,
 		log:                    log,
-		nextSegment:            make(chan nzb.NzbSegment, 200),
+		nextSegment:            make(chan nzb.NzbSegment),
 		wg:                     &sync.WaitGroup{},
 		currentDownloading:     &sync.Map{},
 		filePath:               filePath,
@@ -144,6 +131,9 @@ func (b *buffer) Seek(offset int64, whence int) (int64, error) {
 	}
 	b.ptr = abs
 
+	currentSegmentIndex := int(float64(b.ptr) / float64(b.chunkSize))
+	b.deleteSegmentsBeforeCurrentSegment(currentSegmentIndex)
+
 	return abs, nil
 }
 
@@ -154,6 +144,11 @@ func (b *buffer) Close() error {
 	if b.dc.maxDownloadWorkers > 0 {
 		b.wg.Wait()
 	}
+
+	b.segmentsBuffer.Range(func(key, _ interface{}) bool {
+		b.segmentsBuffer.Delete(key)
+		return true
+	})
 
 	b.segmentsBuffer = nil
 	b.nzbReader = nil
@@ -197,6 +192,15 @@ func (b *buffer) ReadAt(p []byte, off int64) (int, error) {
 	return b.read(p, currentSegmentIndex, beginReadAt)
 }
 
+func (b *buffer) deleteSegmentsBeforeCurrentSegment(currentSegmentIndex int) {
+	b.segmentsBuffer.Range(func(key, _ interface{}) bool {
+		if key.(int) < currentSegmentIndex {
+			b.segmentsBuffer.Delete(key)
+		}
+		return true
+	})
+}
+
 func (b *buffer) read(p []byte, currentSegmentIndex, beginReadAt int) (int, error) {
 	n := 0
 	br := beginReadAt
@@ -204,15 +208,18 @@ func (b *buffer) read(p []byte, currentSegmentIndex, beginReadAt int) (int, erro
 	// Preload next segments
 	for j := 0; j < b.dc.maxDownloadWorkers; j++ {
 		nextSegmentIndex := currentSegmentIndex + j
-		if _, ok := b.segmentsBuffer.Load([]byte(fmt.Sprint(nextSegmentIndex))); !ok {
+		if _, ok := b.segmentsBuffer.Load(nextSegmentIndex); !ok {
 			if nextSegment, hasMore := b.nzbReader.GetSegment(nextSegmentIndex); hasMore {
-				b.nextSegment <- nextSegment
+				if _, loaded := b.currentDownloading.Load(nextSegment.Number); !loaded {
+					b.nextSegment <- nextSegment
+				}
 			}
 		}
 	}
 
 	i := 0
 	retries := 0
+	var chunk []byte
 	for {
 		if n >= len(p) {
 			b.ptr += int64(n)
@@ -220,7 +227,7 @@ func (b *buffer) read(p []byte, currentSegmentIndex, beginReadAt int) (int, erro
 			return n, nil
 		}
 
-		segment, ok := b.segmentsBuffer.Load([]byte(fmt.Sprint(currentSegmentIndex + i)))
+		segment, ok := b.segmentsBuffer.LoadAndDelete(currentSegmentIndex + i)
 		if !ok {
 
 			if retries >= b.downloadRetryTimeoutMs {
@@ -242,19 +249,25 @@ func (b *buffer) read(p []byte, currentSegmentIndex, beginReadAt int) (int, erro
 				continue
 			}
 		}
-		i++
-		chunk := segment
+
+		chunk = segment.([]byte)
 
 		beginWriteAt := n
 		n += copy(p[beginWriteAt:], chunk[br:])
+
+		if n < len(chunk[br:]) {
+			b.segmentsBuffer.Store(currentSegmentIndex+i, chunk)
+		}
+
 		chunk = nil
 		br = 0
 		retries = 0
+		i++
 	}
 }
 
 func (b *buffer) downloadSegment(ctx context.Context, segment nzb.NzbSegment, groups []string) ([]byte, error) {
-	chunk := make([]byte, segment.Bytes)
+	chunk := make([]byte, b.chunkSize)
 	var conn connectionpool.Resource
 	retryErr := retry.Do(func() error {
 		c, err := b.cp.GetDownloadConnection(ctx)
@@ -282,9 +295,12 @@ func (b *buffer) downloadSegment(ctx context.Context, segment nzb.NzbSegment, gr
 			}
 		}
 
-		chunk, err = nntpConn.Body(fmt.Sprintf("<%v>", segment.Id))
+		err = nntpConn.Body(fmt.Sprintf("<%v>", segment.Id), chunk)
 		if err != nil {
-			return fmt.Errorf("error getting body: %w", err)
+			// Final segments has less bytes than chunkSize. Do not error if it's the case
+			if err != io.ErrUnexpectedEOF {
+				return fmt.Errorf("error getting body: %w", err)
+			}
 		}
 
 		b.cp.Free(conn)
@@ -364,6 +380,10 @@ func (b *buffer) downloadWorker(ctx context.Context, cNzb corruptednzbsmanager.C
 			if _, loaded := b.currentDownloading.LoadOrStore(segment.Number, true); loaded {
 				continue
 			}
+			segmentIndex := int(segment.Number - 1)
+			if _, ok := b.segmentsBuffer.Load(segmentIndex); ok {
+				continue
+			}
 
 			chunk, err := b.downloadSegment(ctx, segment, b.nzbGroups)
 			if err != nil && !errors.Is(err, context.Canceled) {
@@ -377,8 +397,7 @@ func (b *buffer) downloadWorker(ctx context.Context, cNzb corruptednzbsmanager.C
 			}
 
 			if err == nil {
-				segmentIndex := fmt.Sprint(segment.Number - 1)
-				b.segmentsBuffer.Store([]byte(segmentIndex), chunk)
+				b.segmentsBuffer.Store(segmentIndex, chunk)
 			}
 
 			b.currentDownloading.Delete(segment.Number)

--- a/pkg/nntpcli/connection.go
+++ b/pkg/nntpcli/connection.go
@@ -26,7 +26,7 @@ type Connection interface {
 	io.Closer
 	Authenticate() (err error)
 	JoinGroup(name string) error
-	Body(msgId string) ([]byte, error)
+	Body(msgId string, chunk []byte) error
 	Post(r io.Reader) error
 	Provider() Provider
 	CurrentJoinedGroup() string
@@ -132,21 +132,18 @@ func (c *connection) CurrentJoinedGroup() string {
 }
 
 // Body gets the decoded body of an article
-func (c *connection) Body(msgId string) ([]byte, error) {
+func (c *connection) Body(msgId string, chunk []byte) error {
 	_, _, err := c.sendCmd(fmt.Sprintf("BODY %s", msgId), 222)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	defer c.decoder.Reset()
 	c.decoder.SetReader(bufio.NewReader(c.conn.R))
 
-	chunk, err := io.ReadAll(c.decoder)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding the body: %w", err)
-	}
+	_, err = io.ReadFull(c.decoder, chunk)
 
-	return chunk, nil
+	return err
 }
 
 // Post a new article

--- a/pkg/nntpcli/connection.go
+++ b/pkg/nntpcli/connection.go
@@ -133,7 +133,7 @@ func (c *connection) CurrentJoinedGroup() string {
 
 // Body gets the decoded body of an article
 func (c *connection) Body(msgId string, chunk []byte) error {
-	_, _, err := c.sendCmd(fmt.Sprintf("BODY %s", msgId), 222)
+	_, _, err := c.sendCmd(fmt.Sprintf("BODY <%s>", msgId), 222)
 	if err != nil {
 		return err
 	}

--- a/pkg/nntpcli/connection_mock.go
+++ b/pkg/nntpcli/connection_mock.go
@@ -49,18 +49,17 @@ func (mr *MockConnectionMockRecorder) Authenticate() *gomock.Call {
 }
 
 // Body mocks base method.
-func (m *MockConnection) Body(msgId string) ([]byte, error) {
+func (m *MockConnection) Body(msgId string, chunk []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Body", msgId)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "Body", msgId, chunk)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Body indicates an expected call of Body.
-func (mr *MockConnectionMockRecorder) Body(msgId interface{}) *gomock.Call {
+func (mr *MockConnectionMockRecorder) Body(msgId, chunk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Body", reflect.TypeOf((*MockConnection)(nil).Body), msgId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Body", reflect.TypeOf((*MockConnection)(nil).Body), msgId, chunk)
 }
 
 // Close mocks base method.

--- a/pkg/nntpcli/fake_connection.go
+++ b/pkg/nntpcli/fake_connection.go
@@ -1,6 +1,8 @@
 package nntpcli
 
-import "io"
+import (
+	"io"
+)
 
 type fakeConnection struct {
 	tls          bool
@@ -35,8 +37,8 @@ func (c *fakeConnection) Close() error {
 	return nil
 }
 
-func (c *fakeConnection) Body(msgId string) ([]byte, error) {
-	return []byte{}, nil
+func (c *fakeConnection) Body(msgId string, chunk []byte) error {
+	return nil
 }
 
 func (c *fakeConnection) Post(r io.Reader) error {


### PR DESCRIPTION
perf: improve cache system by using sync.Map
BREAKING CHANGE: remove max_buffer_size_in_mb from config

A new segment cache system is implemented in which segments are buffered while the reader just get and removes the segment from the cache instantly and if needed it will put it back. Also file seeks will remove older o newer segments.