### PR TITLE
perf: reuse chunks on read

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The `Download` struct defines the Usenet provider for downloading.
 
 ### Fields
 
-- `max_download_workers` (int): The maximum number of download workers. Default value is `3`. WARN the tool will use 1 connections per worker. Min value is 1.
+- `max_download_workers` (int): The maximum number of download workers. Default value is `5`. WARN the tool will use 1 connections per worker. Min value is 1. The number observed optimal for good speed is 5.
 - `max_retries` (int): The maximum number of retries to download a segment. Default value is `8`.
 - `providers` (UsenetProvider): Usenet providers to download files. (It is recommended an unlimited provider for this)
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -4,7 +4,7 @@ api_port: 8081
 db_path: /config/usenet-drive.db
 usenet:
   download:
-    max_download_workers: 3
+    max_download_workers: 5
     providers:
       - host: post.otherusenet.server
         port: 119

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Usenet struct {
 }
 
 type Download struct {
-	MaxDownloadWorkers int              `yaml:"max_download_workers" default:"3"`
+	MaxDownloadWorkers int              `yaml:"max_download_workers" default:"5"`
 	MaxRetries         int              `yaml:"max_retries" default:"8"`
 	Providers          []UsenetProvider `yaml:"providers"`
 }

--- a/internal/usenet/filereader/buffer_test.go
+++ b/internal/usenet/filereader/buffer_test.go
@@ -668,7 +668,8 @@ func TestBuffer_downloadSegment(t *testing.T) {
 			copy(chunk, []byte(expectedBody1))
 		}).Return(nil).Times(1)
 
-		part, err := buf.downloadSegment(context.Background(), segment, groups)
+		part := make([]byte, 5)
+		err := buf.downloadSegment(context.Background(), segment, groups, part)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("body1"), part)
 	})
@@ -701,7 +702,8 @@ func TestBuffer_downloadSegment(t *testing.T) {
 		}
 		mockPool.EXPECT().GetDownloadConnection(gomock.Any()).Return(nil, errors.New("error")).Times(1)
 
-		_, err := buf.downloadSegment(context.Background(), segment, groups)
+		part := make([]byte, 5)
+		err := buf.downloadSegment(context.Background(), segment, groups, part)
 		assert.Error(t, err)
 	})
 
@@ -740,7 +742,8 @@ func TestBuffer_downloadSegment(t *testing.T) {
 		mockPool.EXPECT().Close(mockResource).Times(1)
 		mockConn.EXPECT().JoinGroup("group1").Return(errors.New("error")).Times(1)
 
-		_, err := buf.downloadSegment(context.Background(), segment, groups)
+		part := make([]byte, 5)
+		err := buf.downloadSegment(context.Background(), segment, groups, part)
 		assert.Error(t, err)
 	})
 
@@ -782,7 +785,8 @@ func TestBuffer_downloadSegment(t *testing.T) {
 
 		mockConn.EXPECT().Body("1", gomock.Any()).Return(errors.New("some error")).Times(1)
 
-		_, err := buf.downloadSegment(context.Background(), segment, groups)
+		part := make([]byte, 5)
+		err := buf.downloadSegment(context.Background(), segment, groups, part)
 		assert.ErrorIs(t, err, ErrCorruptedNzb)
 	})
 
@@ -840,7 +844,8 @@ func TestBuffer_downloadSegment(t *testing.T) {
 			return nil
 		}).Times(1)
 
-		part, err := buf.downloadSegment(context.Background(), segment, groups)
+		part := make([]byte, 5)
+		err := buf.downloadSegment(context.Background(), segment, groups, part)
 		assert.NoError(t, err)
 		assert.NotNil(t, part)
 		assert.Equal(t, []byte("body1"), part)
@@ -897,7 +902,8 @@ func TestBuffer_downloadSegment(t *testing.T) {
 			copy(chunk, []byte(expectedBody1))
 		}).Return(nil).Times(1)
 
-		part, err := buf.downloadSegment(context.Background(), segment, groups)
+		part := make([]byte, 5)
+		err := buf.downloadSegment(context.Background(), segment, groups, part)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, part)

--- a/internal/usenet/filereader/utils.go
+++ b/internal/usenet/filereader/utils.go
@@ -28,3 +28,7 @@ func getOriginalNzb(fs osfs.FileSystem, name string) osfs.FileInfo {
 
 	return stat
 }
+
+func segmentIndexFromSegmentNumber(segmentNumber int64) int {
+	return int(segmentNumber) - 1
+}


### PR DESCRIPTION
fix: do not return timeout for last segment
perf: reuse the chunks on download