### PR TITLE
fix: null pointer reference 

### DIFF
--- a/internal/usenet/filewriter/file.go
+++ b/internal/usenet/filewriter/file.go
@@ -412,6 +412,12 @@ func (f *file) addSegment(ctx context.Context, conn connectionpool.Resource, seg
 		}
 
 		nntpConn := conn.Value()
+		if nntpConn == nil {
+			f.cp.Close(conn)
+			conn = nil
+
+			return fmt.Errorf("error getting the connection %w", ErrRetryable)
+		}
 		err = nntpConn.Post(articleReader)
 		if err != nil {
 			return fmt.Errorf("error posting article: %w", err)

--- a/internal/usenet/filewriter/file.go
+++ b/internal/usenet/filewriter/file.go
@@ -387,8 +387,8 @@ func (f *file) addSegment(ctx context.Context, conn connectionpool.Resource, seg
 		if conn == nil {
 			c, err := f.cp.GetUploadConnection(ctx)
 			if err != nil {
-				if conn != nil {
-					f.cp.Close(conn)
+				if c != nil {
+					f.cp.Close(c)
 					conn = nil
 				}
 


### PR DESCRIPTION
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x8c983d]
goroutine 2007 [running]:
github.com/javi11/usenet-drive/internal/usenet/filewriter.(*file).addSegment.func1()
	/app/internal/usenet/filewriter/file.go:415 +0x71d